### PR TITLE
[feat] MAC4-17 로그아웃 기능 구현 (#10)

### DIFF
--- a/src/main/java/com/mac4/yeopabackend/user/controller/AuthController.java
+++ b/src/main/java/com/mac4/yeopabackend/user/controller/AuthController.java
@@ -4,30 +4,27 @@ import com.mac4.yeopabackend.common.response.ApiResponse;
 import com.mac4.yeopabackend.user.dto.request.LoginRequestDto;
 import com.mac4.yeopabackend.user.dto.request.SignUpRequestDto;
 import com.mac4.yeopabackend.user.dto.response.TokenResponseDto;
-import com.mac4.yeopabackend.user.service.UserService;
+import com.mac4.yeopabackend.user.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
 public class AuthController {
 
-    private final UserService userService;
+    private final AuthService authService;
 
     @PostMapping("/signup")
     public ApiResponse<TokenResponseDto> signup(@Valid @RequestBody SignUpRequestDto signUpRequestDto){
-        TokenResponseDto token = userService.signUp(signUpRequestDto);
+        TokenResponseDto token = authService.signUp(signUpRequestDto);
         return ApiResponse.success(token);
     }
 
     @PostMapping("/login")
     public ApiResponse<TokenResponseDto> login(@Valid @RequestBody LoginRequestDto loginRequestDto){
-        TokenResponseDto token = userService.login(loginRequestDto);
+        TokenResponseDto token = authService.login(loginRequestDto);
         return ApiResponse.success(token);
     }
 }

--- a/src/main/java/com/mac4/yeopabackend/user/controller/UserController.java
+++ b/src/main/java/com/mac4/yeopabackend/user/controller/UserController.java
@@ -1,0 +1,23 @@
+package com.mac4.yeopabackend.user.controller;
+
+import com.mac4.yeopabackend.common.response.ApiResponse;
+import com.mac4.yeopabackend.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/user")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/logout")
+    public ApiResponse<Void> logout(@RequestHeader("Authorization") String authorization){
+        userService.logout(authorization);
+        return ApiResponse.success();
+    }
+}

--- a/src/main/java/com/mac4/yeopabackend/user/service/AuthService.java
+++ b/src/main/java/com/mac4/yeopabackend/user/service/AuthService.java
@@ -1,0 +1,66 @@
+package com.mac4.yeopabackend.user.service;
+
+import com.mac4.yeopabackend.common.exception.BusinessException;
+import com.mac4.yeopabackend.common.exception.ErrorCode;
+import com.mac4.yeopabackend.common.jwt.JwtTokenProvider;
+import com.mac4.yeopabackend.common.jwt.TokenBlacklistStore;
+import com.mac4.yeopabackend.user.domain.User;
+import com.mac4.yeopabackend.user.dto.request.LoginRequestDto;
+import com.mac4.yeopabackend.user.dto.request.SignUpRequestDto;
+import com.mac4.yeopabackend.user.dto.response.TokenResponseDto;
+import com.mac4.yeopabackend.user.repository.UserRepository;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    // 회원가입
+    @Transactional
+    public TokenResponseDto signUp(SignUpRequestDto request){
+
+        if(userRepository.existsByEmail(request.email())){
+            throw new BusinessException(ErrorCode.USER_EMAIL_DUPLICATED);
+        }
+
+        String encodedPassword = passwordEncoder.encode(request.password());
+
+        User user = User.builder()
+                .email(request.email())
+                .password(encodedPassword)
+                .username(request.username())
+                .description(request.description())
+                .build();
+
+        userRepository.save(user);
+
+        String accessToken = jwtTokenProvider.createToken(user.getId(), user.getEmail());
+
+        return new TokenResponseDto(accessToken);
+    }
+
+    @Transactional
+    public TokenResponseDto login(@Valid LoginRequestDto request) {
+
+        User user = userRepository.findByEmail(request.email())
+                .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_LOGIN_FAILED));
+
+        if(!passwordEncoder.matches(request.password(), user.getPassword())){
+            throw new BusinessException(ErrorCode.AUTH_LOGIN_FAILED);
+        }
+
+        String accessToken = jwtTokenProvider.createToken(user.getId(), user.getEmail());
+
+        return new TokenResponseDto(accessToken);
+    }
+
+}

--- a/src/main/java/com/mac4/yeopabackend/user/service/UserService.java
+++ b/src/main/java/com/mac4/yeopabackend/user/service/UserService.java
@@ -2,65 +2,29 @@ package com.mac4.yeopabackend.user.service;
 
 import com.mac4.yeopabackend.common.exception.BusinessException;
 import com.mac4.yeopabackend.common.exception.ErrorCode;
-import com.mac4.yeopabackend.common.jwt.JwtTokenProvider;
-import com.mac4.yeopabackend.user.domain.User;
-import com.mac4.yeopabackend.user.dto.request.LoginRequestDto;
-import com.mac4.yeopabackend.user.dto.request.SignUpRequestDto;
-import com.mac4.yeopabackend.user.dto.response.TokenResponseDto;
-import com.mac4.yeopabackend.user.repository.UserRepository;
-import jakarta.validation.Valid;
+import com.mac4.yeopabackend.common.jwt.TokenBlacklistStore;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class UserService {
 
-    private final UserRepository userRepository;
-    private final PasswordEncoder passwordEncoder;
-    private final JwtTokenProvider jwtTokenProvider;
+    private final TokenBlacklistStore tokenBlacklistStore;
 
-    // 회원가입
     @Transactional
-    public TokenResponseDto signUp(SignUpRequestDto request){
-
-        if(userRepository.existsByEmail(request.email())){
-            throw new BusinessException(ErrorCode.USER_EMAIL_DUPLICATED);
-        }
-
-        String encodedPassword = passwordEncoder.encode(request.password());
-
-        User user = User.builder()
-                .email(request.email())
-                .password(encodedPassword)
-                .username(request.username())
-                .description(request.description())
-                .build();
-
-        userRepository.save(user);
-
-        String accessToken = jwtTokenProvider.createToken(user.getId(), user.getEmail());
-
-        return new TokenResponseDto(accessToken);
+    public void logout(String authorization) {
+        String token = extractToken(authorization);
+        tokenBlacklistStore.blacklist(token);
     }
 
-    @Transactional
-    public TokenResponseDto login(@Valid LoginRequestDto request) {
-
-        User user = userRepository.findByEmail(request.email())
-                .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_LOGIN_FAILED));
-
-        if(!passwordEncoder.matches(request.password(), user.getPassword())){
-            throw new BusinessException(ErrorCode.AUTH_LOGIN_FAILED);
+    // accessToken 헤더 제거
+    private String extractToken(String authorization){
+        if(authorization == null || !authorization.startsWith("Bearer ")){
+            throw new BusinessException(ErrorCode.AUTH_UNAUTHORIZED);
         }
-
-        String accessToken = jwtTokenProvider.createToken(user.getId(), user.getEmail());
-
-        return new TokenResponseDto(accessToken);
+        return authorization.substring(7);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

closes #10 

## #️⃣ 작업 내용
- 로그아웃 시 Access Token을 Redis 블랙리스트에 저장하도록 기능 구현
- JWT 인증 필터에서 블랙리스트에 등록된 토큰을 검증하여 인증 차단 처리
- Redis TTL을 Access Token의 남은 만료 시간으로 설정하여 자동 정리되도록 구현
- 로그아웃 엔드포인트 : POST/api/v1/user/logout

## #️⃣ 테스트 결과
- 로그아웃 성공
<img width="1420" height="1188" alt="image" src="https://github.com/user-attachments/assets/6196e440-6dfe-4eb4-a0dc-297e53289e56" />

- Postman을 통해 로그인 → 로그아웃 → 동일 토큰 재요청 시 인증 실패(401) 정상 동작 확인
<img width="717" height="549" alt="스크린샷 2026-01-19 오전 11 48 44" src="https://github.com/user-attachments/assets/859cc608-ca53-46e3-b0bc-76715bc299df" />

- Redis CLI에서 블랙리스트 키(`bl:{token}`) 저장 
<img width="1522" height="174" alt="image" src="https://github.com/user-attachments/assets/8a8e583d-9681-4403-ba65-bd15ce84cbc6" />

- 블랙리스트에 등록된 토큰으로 보호 API 접근 시 `JWT is blacklisted` 로그 출력 확인
<img width="1337" height="275" alt="스크린샷 2026-01-19 오전 11 46 49" src="https://github.com/user-attachments/assets/faaa7f62-25f4-4a2e-88fa-d6cdecdf8f32" />

## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## #️⃣ 리뷰 요구사항 (선택)

> 테스트 사진에서의 엔드포인트 주소는 auth이나 user로 테스트하시면 됩니다

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 로그아웃 엔드포인트 추가: 사용자가 이제 로그아웃할 수 있으며, 로그아웃 시 토큰이 무효화됩니다.

* **개선**
  * 인증 서비스 구조 재정비를 통해 회원가입, 로그인, 로그아웃 기능이 더욱 안정적으로 동작합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->